### PR TITLE
styled back-end validation messages

### DIFF
--- a/assets/css/components/_form.scss
+++ b/assets/css/components/_form.scss
@@ -8,7 +8,8 @@
             width: 100%;
         }
 
-        & > div:first-child {
+        & > div:first-child,
+        & > ul:first-child {
             margin-right: rem(30px);
         }
 
@@ -24,6 +25,12 @@
     &__field {
         position: relative;
         margin-bottom: 1rem;
+    }
+
+    &__error {
+        position: relative;
+        top: rem(-12px);
+        color: #D8000C;
     }
 
     input {

--- a/templates/registration/register.html.twig
+++ b/templates/registration/register.html.twig
@@ -15,38 +15,48 @@
                         {{ form_widget(registrationForm.firstname) }}
                         {{ form_label(registrationForm.firstname) }}
                     </div>
-                    {{ form_errors(registrationForm.firstname) }}
 
                     <div class="form__field form__field--half">
                         {{ form_widget(registrationForm.lastname) }}
                         {{ form_label(registrationForm.lastname) }}
                     </div>
                 </div>
-                {{ form_errors(registrationForm.lastname) }}
+                <div class="form__fields form__error">
+                        {{ form_errors(registrationForm.firstname) }}
+                        {{ form_errors(registrationForm.lastname) }}
+                    </div>
 
                 <div class="form__field">
                     {{ form_widget(registrationForm.username) }}
                     {{ form_label(registrationForm.username) }}
                 </div>
-                {{ form_errors(registrationForm.username) }}
+                <div class="form__error">
+                    {{ form_errors(registrationForm.username) }}
+                </div>
 
                 <div class="form__field">
                     {{ form_widget(registrationForm.email) }}
                     {{ form_label(registrationForm.email) }}
                 </div>
-                {{ form_errors(registrationForm.email) }}
+                <div class="form__error">
+                    {{ form_errors(registrationForm.email) }}
+                </div>
 
                 <div class="form__field">
                     {{ form_widget(registrationForm.phoneNumber) }}
                     {{ form_label(registrationForm.phoneNumber) }}
                 </div>
-                {{ form_errors(registrationForm.phoneNumber) }}
+                <div class="form__error">
+                    {{ form_errors(registrationForm.phoneNumber) }}
+                </div> 
 
                 <div class="form__field">
                     {{ form_widget(registrationForm.plainPassword) }}
                     {{ form_label(registrationForm.plainPassword) }}
                 </div>
-                {{ form_errors(registrationForm.plainPassword) }}
+                <div class="form__error">
+                    {{ form_errors(registrationForm.plainPassword) }}
+                </div>
 
                 <button class="btn btn--full">{{ "registration_form.register.button"|trans }}</button>
 

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -8,7 +8,9 @@
             <div class="login__window col-lg-5">
                 <form method="post" class="form">
                     {% if error %}
-                        <div class="alert alert-danger">{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+                        <div class="form__error">
+                            {{ error.messageKey|trans(error.messageData, 'security') }}
+                        </div>
                     {% endif %}
 
                     {% if app.user %}


### PR DESCRIPTION
Tried to style back-end validation messages. Good news that works and looks nice, bad news that I think it is a dirty way to wrap every error inside div, however, not found if it is possible to add class to error field. I guess the only way is to create a custom form, maybe Dominykas will know more about it. Also, it is very weird that error is rendered in the unordered list. Like this:
<ul>
  <li> Please enter your firstname </li>
<ul>
